### PR TITLE
Added protobuf and ortools prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ git clone <repo_address> (or copy the repo folder to here)
 ## Prerequisites
 - Protobuf
   - Ubuntu 22.04: `sudo apt install libprotobuf-dev protobuf-compiler`
-
+- Google OR Tools
+  - Ubuntu 22.04:
+    - [build from source and install](https://developers.google.com/optimization/install/cpp/source_linux)
 ## Using Docker
 If you would like to build and run everything in Docker, follow the instructions in `docker/notes.md`. Otherwise, the stack was built using Ubuntu 22.04 with ROS Humble. 
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,14 @@ cd inspection_ws/src
 git clone <repo_address> (or copy the repo folder to here)
 ```
 
+## Prerequisites
+- Protobuf
+  - Ubuntu 22.04: `sudo apt install libprotobuf-dev protobuf-compiler`
+
 ## Using Docker
 If you would like to build and run everything in Docker, follow the instructions in `docker/notes.md`. Otherwise, the stack was built using Ubuntu 22.04 with ROS Humble. 
 
-## Building 
+## Building
 Navigate to the workspace directory and run
 ```sh
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Protobuf is required to build using the instructions provided. It is not always already installed on ubuntu 22.04. I added the command to install and listed as a prereq